### PR TITLE
Handle projections, queries on Mongo doc properties (like _id) and fix comparisons to null

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: node_js
 node_js:
+  - 8
   - 5
   - 4
-  - 0.10
 script: "npm run test-cover"
 # Send coverage data to Coveralls
 after_script: "cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: node_js
 node_js:
+  - 9
   - 8
-  - 5
+  - 6
   - 4
 script: "npm run test-cover"
 # Send coverage data to Coveralls

--- a/index.js
+++ b/index.js
@@ -17,6 +17,24 @@ function extendMemoryDB(MemoryDB) {
 
   ShareDBMingo.prototype = Object.create(MemoryDB.prototype);
 
+  ShareDBMingo.prototype.projectsSnapshots = true;
+
+  // HACK: Wrap MemoryDB functions to project snapshots before returning them.
+  //   This would be cleaner if implemented directly in MemoryDB, or it would be
+  //   more aligned with a drop-in sharedb-mongo replacement if implemented as
+  //   mingo projections.
+  ShareDBMingo.prototype.getSnapshot = function(collection, id, fields, options, callback) {
+    MemoryDB.prototype.getSnapshot.call(this, collection, id, fields, options, function (err, snapshot) {
+      callback(err, projectSnapshot(fields, snapshot));
+    });
+  }
+  ShareDBMingo.prototype.query = function(collection, query, fields, options, callback) {
+    MemoryDB.prototype.query.call(this, collection, query, fields, options, function (err, snapshots, extra) {
+      var projectSnapshotWithFields = projectSnapshot.bind(null, fields);
+      callback(err, snapshots.map(projectSnapshotWithFields), extra);
+    });
+  }
+
   ShareDBMingo.prototype._querySync = function(snapshots, query, options) {
     var parsed = parseQuery(query);
     var mingoQuery = new Mingo.Query(castToSnapshotQuery(parsed.query));
@@ -80,6 +98,27 @@ function extendMemoryDB(MemoryDB) {
       skip: skip,
       limit: limit,
       count: count
+    };
+  }
+
+  function projectSnapshot(fields, snapshot) {
+    // Don't project when there's no projection
+    if (!fields) return snapshot;
+    // Don't project when called by ShareDB submit
+    if (fields.$submit) return snapshot;
+
+    var projectedData = {};
+    for (var key in snapshot.data) {
+      if (fields[key]) projectedData[key] = snapshot.data[key];
+    }
+
+    return {
+      id: snapshot.id,
+      v: snapshot.v,
+      type: snapshot.type,
+      m: snapshot.m,
+      o: snapshot.o,
+      data: projectedData
     };
   }
 

--- a/index.js
+++ b/index.js
@@ -25,13 +25,15 @@ function extendMemoryDB(MemoryDB) {
   //   mingo projections.
   ShareDBMingo.prototype.getSnapshot = function(collection, id, fields, options, callback) {
     MemoryDB.prototype.getSnapshot.call(this, collection, id, fields, options, function (err, snapshot) {
-      callback(err, projectSnapshot(fields, snapshot));
+      if (err) return callback(err);
+      callback(null, projectSnapshot(fields, snapshot));
     });
   }
   ShareDBMingo.prototype.query = function(collection, query, fields, options, callback) {
     MemoryDB.prototype.query.call(this, collection, query, fields, options, function (err, snapshots, extra) {
+      if (err) return callback(err);
       var projectSnapshotWithFields = projectSnapshot.bind(null, fields);
-      callback(err, snapshots.map(projectSnapshotWithFields), extra);
+      callback(null, (snapshots || []).map(projectSnapshotWithFields), extra);
     });
   }
 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/share/sharedb-mingo-memory#readme",
   "dependencies": {
-    "mingo": "^0.6.3",
+    "mingo": "^2.2.0",
     "sharedb": "^1.0.0-beta"
   }
 }

--- a/test/query.js
+++ b/test/query.js
@@ -50,7 +50,51 @@ module.exports = function() {
     });
   });
 
-  describe('top-level boolean operator', function(done) {
+  it('filters with top-level _id condition', function(done) {
+    var snapshots = [
+      {type: 'json0', v: 1, data: {x: 1, y: 1}, id: "test1"},
+      {type: 'json0', v: 1, data: {x: 1, y: 2}, id: "test2"},
+      {type: 'json0', v: 1, data: {x: 2, y: 2}, id: "test3"}
+    ];
+    var query = {_id: {$in: ['test1', 'test3']}};
+
+    var db = this.db;
+    async.each(snapshots, function(snapshot, cb) {
+      db.commit('testcollection', snapshot.id, {v: 0, create: {}}, snapshot, null, cb);
+    }, function(err) {
+      if (err) return done(err);
+
+      db.query('testcollection', query, null, null, function(err, results, extra) {
+        if (err) throw err;
+        expect(results).eql([snapshots[0], snapshots[2]]);
+        done();
+      });
+    });
+  });
+
+  it('filters with null condition', function(done) {
+    var snapshots = [
+      {type: 'json0', v: 1, data: {x: 1, y: 1}, id: "test1"},
+      {type: 'json0', v: 1, data: {x: 1}, id: "test2"}, // y value intentionally omitted
+      {type: 'json0', v: 1, data: {x: 2, y: 2}, id: "test3"}
+    ];
+    var query = {y: null};
+
+    var db = this.db;
+    async.each(snapshots, function(snapshot, cb) {
+      db.commit('testcollection', snapshot.id, {v: 0, create: {}}, snapshot, null, cb);
+    }, function(err) {
+      if (err) return done(err);
+
+      db.query('testcollection', query, null, null, function(err, results, extra) {
+        if (err) throw err;
+        expect(results).eql([snapshots[1]]);
+        done();
+      });
+    });
+  });
+
+  describe('top-level boolean operator', function() {
     var snapshots = [
       {type: 'json0', v: 1, data: {x: 1, y: 1}, id: "test1"},
       {type: 'json0', v: 1, data: {x: 1, y: 2}, id: "test2"},


### PR DESCRIPTION
These changes bring `sharedb-mingo-memory` closer to a drop-in replacement for `sharedb-mongo`

### Changes

* Add support for sharedb projections (already has test coverage)
* Transform `mingo` query conditions to mimic execution of how they'd perform on Mongo docs persisted by `sharedb-mongo`
* Update `mingo` dependency to fix `<property>: null` queries
* Add tests for ^