### PR TITLE
Add null snapshot metadata

### DIFF
--- a/test/query.js
+++ b/test/query.js
@@ -36,9 +36,9 @@ module.exports = function() {
 
   it('$sort, $skip and $limit should order, skip and limit', function(done) {
     var snapshots = [
-      {type: 'json0', v: 1, data: {x: 1}, id: "test1"},
-      {type: 'json0', v: 1, data: {x: 3}, id: "test2"}, // intentionally added out of sort order
-      {type: 'json0', v: 1, data: {x: 2}, id: "test3"}
+      {type: 'json0', v: 1, data: {x: 1}, id: "test1", m: null},
+      {type: 'json0', v: 1, data: {x: 3}, id: "test2", m: null}, // intentionally added out of sort order
+      {type: 'json0', v: 1, data: {x: 2}, id: "test3", m: null}
     ];
     var query = {$sort: {x: 1}, $skip: 1, $limit: 1};
 
@@ -72,7 +72,7 @@ module.exports = function() {
     ];
     var snapshotsNoMeta = snapshots.map(function(snapshot) {
       var snapshotCopy = JSON.parse(JSON.stringify(snapshot));
-      delete snapshotCopy.m;
+      snapshotCopy.m = null;
       return snapshotCopy;
     });
 
@@ -123,9 +123,9 @@ module.exports = function() {
 
   it('filters with null condition', function(done) {
     var snapshots = [
-      {type: 'json0', v: 1, data: {x: 1, y: 1}, id: "test1"},
-      {type: 'json0', v: 1, data: {x: 1}, id: "test2"}, // y value intentionally omitted
-      {type: 'json0', v: 1, data: {x: 2, y: 2}, id: "test3"}
+      {type: 'json0', v: 1, data: {x: 1, y: 1}, id: "test1", m: null},
+      {type: 'json0', v: 1, data: {x: 1}, id: "test2", m: null}, // y value intentionally omitted
+      {type: 'json0', v: 1, data: {x: 2, y: 2}, id: "test3", m: null}
     ];
     var query = {y: null};
 
@@ -145,9 +145,9 @@ module.exports = function() {
 
   describe('top-level boolean operator', function() {
     var snapshots = [
-      {type: 'json0', v: 1, data: {x: 1, y: 1}, id: "test1"},
-      {type: 'json0', v: 1, data: {x: 1, y: 2}, id: "test2"},
-      {type: 'json0', v: 1, data: {x: 2, y: 2}, id: "test3"}
+      {type: 'json0', v: 1, data: {x: 1, y: 1}, id: "test1", m: null},
+      {type: 'json0', v: 1, data: {x: 1, y: 2}, id: "test2", m: null},
+      {type: 'json0', v: 1, data: {x: 2, y: 2}, id: "test3", m: null}
     ];
 
     beforeEach(function(done) {


### PR DESCRIPTION
We recently replaced `MemorySnapshot` with a more generic `Snapshot`
class, which [always has the `m` property set][1].

That change breaks some of the tests in this library, which don't have
the `m` metadata property defined. This change updates those failing
tests.

[1]: https://github.com/share/sharedb/pull/220/files#diff-09a9af1416a54a5b125a5c2e1e6c2a30R7