### PR TITLE
Add support for querying sharedb meta fields

### DIFF
--- a/test/query.js
+++ b/test/query.js
@@ -91,12 +91,7 @@ module.exports = function() {
       });
     });
 
-    // The simpler query-casting approach doesn't handle queries that filter on
-    // sub-properties of the Share metadata object. An alternative would be to
-    // rewrite this module to cast Share snapshots to Mongo docs and vice versa,
-    // the same way that sharedb-mongo does:
-    // https://github.com/share/sharedb-mingo-memory/pull/3#pullrequestreview-99017385
-    it.skip('condition on sub-property under Share metadata', function(done) {
+    it('condition on sub-property under Share metadata', function(done) {
       this.db.query('testcollection', {'_m.mtime': 1001}, null, null, function(err, results, extra) {
         if (err) throw err;
         expect(results).eql([snapshotsNoMeta[1]]);


### PR DESCRIPTION
### Changes
This change adds support for making queries against the ShareDB doc's meta property.

There are two distinct changes in this PR:

1. Add a workaround for ShareDB's MemoryDB behavior of removing metadata from the snapshot before filtering is executed. Previously the snapshots that were passed in to `_querySync` did not have metadata unless explicitly defined in the query options, thus preventing any filtering to be done with the meta fields.

2. Use a property segment to check if the property should be considered a `MONGO_DOC_PROPERTY`. Previously the check was using the entire property name which prevented nesting the property paths such as `_m.mtime`.

### Notes
There has been some [discussion](https://github.com/share/sharedb-mingo-memory/issues/4) about refactoring this adapter to use snapshot casting instead of query casting. The changes in this PR are not addressing any of that, but is instead providing an interim implementation so the meta fields can be used for querying purposes.