### PR TITLE
Freeze mingo version

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "url": "git://github.com/share/sharedb-mingo-memory.git"
   },
   "dependencies": {
-    "mingo": "^2.2.0"
+    "mingo": "2.5.0"
   },
   "peerDependencies": {
     "sharedb": "^1.0.0-beta"


### PR DESCRIPTION
The latest update in `mingo` breaks nodejs requires, which breaks the usage of this module. This PR freezes the version temporarily until a fix for `mingo` ships.

https://github.com/kofrasa/mingo/issues/125