### PR TITLE
Unpin Mingo

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "url": "git://github.com/share/sharedb-mingo-memory.git"
   },
   "dependencies": {
-    "mingo": "2.5.0"
+    "mingo": "^2.5.2"
   },
   "peerDependencies": {
     "sharedb": "^1.0.0-beta"


### PR DESCRIPTION
`mingo@2.5.2` fixes https://github.com/kofrasa/mingo/issues/125, which caused our builds to fail. Now that the fix is out, let's unpin from `mingo@2.5.0`.