### PR TITLE
[fix] Ignore $hint and $comment in queries

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "coveralls": "^3.0.7",
     "mocha": "^6.2.2",
     "nyc": "^14.1.1",
+    "ot-json1": "^1.0.1",
     "sharedb": "^1.0.0-beta"
   },
   "author": "Avital Oliver",


### PR DESCRIPTION
This fixes an issue where using `$hint` or `$comment` in queries would cause sharedb-mingo-memory to match nothing. Those are normally mapped by sharedb-mongo to cursor `.hint()` and `.comment()` calls.

Mingo does not have special handling for them since there isn't any point to supporting them for simple in-memory filtering, so this PR just strips out `$hint` and `$comment`.