### PR TITLE
Allow regex in queries

### DIFF
--- a/get-query.js
+++ b/get-query.js
@@ -1,3 +1,5 @@
+var cloneDeep = require('lodash.clonedeep');
+
 // Given a key/value comparison query, return a query object with that
 // filter and a specified sort order. The 'order' argument looks like
 // [['foo', 1], ['bar', -1]] for sort by foo asending, then bar
@@ -17,7 +19,7 @@ function makeQuery(options) {
         }
         mongoSort[sort[i][0]] = sort[i][1];
       }
-      var query = JSON.parse(JSON.stringify(inputQuery));
+      var query = cloneDeep(inputQuery);
       query.$sort = mongoSort;
       return query;
     }

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 var Mingo = require('mingo');
+var cloneDeep = require('lodash.clonedeep')
 
 // Snapshot properties added to the root doc by `castToDoc()` in sharedb-mongo
 var MONGO_DOC_PROPERTIES = {
@@ -91,7 +92,7 @@ function extendMemoryDB(MemoryDB) {
   };
 
   function parseQuery(inputQuery) {
-    var query = JSON.parse(JSON.stringify(inputQuery));
+    var query = cloneDeep(inputQuery);
 
     if (inputQuery.$orderby)
       console.warn("Warning: query.$orderby deprecated. Use query.$sort instead.");

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "url": "git://github.com/share/sharedb-mingo-memory.git"
   },
   "dependencies": {
+    "lodash.clonedeep": "^4.5.0",
     "mingo": "2.5.0"
   },
   "peerDependencies": {
@@ -24,7 +25,8 @@
     "mocha": "^6.2.2",
     "nyc": "^14.1.1",
     "ot-json1": "^1.0.1",
-    "sharedb": "^1.0.0-beta"
+    "sharedb": "^1.0.0",
+    "sinon": "^11.1.2"
   },
   "author": "Avital Oliver",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "lodash.clonedeep": "^4.5.0",
-    "mingo": "2.5.0"
+    "mingo": "^4.1.5"
   },
   "peerDependencies": {
     "sharedb": "^1.0.0-beta"

--- a/test/query.js
+++ b/test/query.js
@@ -57,9 +57,6 @@ module.exports = function() {
     });
   });
 
-  // Note: Thsi is not working even with the fix for the simple query test above
-  // It appears to be an issue with Mingo itself.
-  // See: https://github.com/kofrasa/mingo/issues/190
   it('supports regex in a $all query', function(done) {
     var snapshots = [
       {type: 'json0', id: 'test1', v: 1, data: {x: 1, y: 1, foo: ['1foo', 'bar']}},

--- a/test/query.js
+++ b/test/query.js
@@ -34,6 +34,56 @@ module.exports = function() {
     });
   });
 
+  it('supports regex in a simple query', function(done) {
+    var snapshots = [
+      {type: 'json0', id: 'test1', v: 1, data: {x: 1, y: 1, foo: '1foo'}},
+      {type: 'json0', id: 'test2', v: 1, data: {x: 2, y: 2, foo: 'foo1'}},
+      {type: 'json0', id: 'test3', v: 1, data: {x: 3, y: 2, foo: 'foo2'}}
+    ];
+    var query = {$count: true, foo: /^foo/};
+
+    var db = this.db;
+    async.each(snapshots, function(snapshot, cb) {
+      db.commit('testcollection', snapshot.id, {v: 0, create: {}}, snapshot, null, cb);
+    }, function(err) {
+      if (err) return done(err);
+      db.query('testcollection', query, null, null, function(err, results, extra) {
+        if (err) return done(err);
+
+        expect(results).eql([]);
+        expect(extra).eql(2);
+        done();
+      });
+    });
+  });
+
+  // Note: Thsi is not working even with the fix for the simple query test above
+  // It appears to be an issue with Mingo itself.
+  // See: https://github.com/kofrasa/mingo/issues/190
+  it('supports regex in a $all query', function(done) {
+    var snapshots = [
+      {type: 'json0', id: 'test1', v: 1, data: {x: 1, y: 1, foo: ['1foo', 'bar']}},
+      {type: 'json0', id: 'test1', v: 1, data: {x: 1, y: 1, foo: ['foo', 'barz']}},
+      {type: 'json0', id: 'test2', v: 1, data: {x: 2, y: 2, foo: ['foo1', 'bar']}},
+      {type: 'json0', id: 'test3', v: 1, data: {x: 3, y: 2, foo: ['foo2', 'bar']}},
+    ];
+    var query = {$count: true, foo: {'$all': [/^foo/, 'bar']}};
+
+    var db = this.db;
+    async.each(snapshots, function(snapshot, cb) {
+      db.commit('testcollection', snapshot.id, {v: 0, create: {}}, snapshot, null, cb);
+    }, function(err) {
+      if (err) return done(err);
+      db.query('testcollection', query, null, null, function(err, results, extra) {
+        if (err) return done(err);
+
+        expect(results).eql([]);
+        expect(extra).eql(2);
+        done();
+      });
+    });
+  });
+
   it('$sort, $skip and $limit should order, skip and limit', function(done) {
     var snapshots = [
       {type: 'json0', v: 1, data: {x: 1}, id: "test1", m: null},


### PR DESCRIPTION
It appears that this is [supported in MongoDB](https://docs.mongodb.com/manual/reference/operator/query/regex/) but not fully supported by our in memory DB

Related to this, there is a further issue in Mingo: https://github.com/kofrasa/mingo/issues/190

