### PR TITLE
⬆️ Bump `sharedb` to v2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "mingo": "^4.1.5"
   },
   "peerDependencies": {
-    "sharedb": "^1.0.0-beta"
+    "sharedb": "^1.0.0-beta || ^2.0.0"
   },
   "devDependencies": {
     "async": "^1.5.2",
@@ -25,7 +25,7 @@
     "mocha": "^6.2.2",
     "nyc": "^14.1.1",
     "ot-json1": "^1.0.1",
-    "sharedb": "^1.0.0-beta",
+    "sharedb": "^2.0.0",
     "sinon": "^11.1.2"
   },
   "author": "Avital Oliver",


### PR DESCRIPTION
`sharedb` was recently bumped to [v2][1]. The only change was that it
officially dropped support for Node.js v10.

Therefore, consumers should be able to run `sharedb-mongo` with either
v1 or v2, which is now reflected in `package.json`.

[1]: https://github.com/share/sharedb/releases/tag/v2.0.0