### PR TITLE
👷 Remove Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,0 @@
-language: node_js
-node_js:
-  - "12"
-  - "10"
-  - "8"
-script: "npm run test-cover"
-# Send coverage data to Coveralls
-after_script: "cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js"


### PR DESCRIPTION
The build now [runs on GitHub Actions][1], so we no longer need this
Travis config.

[1]: https://github.com/share/sharedb-mingo-memory/pull/15