### PR TITLE
✅ Bump `async`

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "sharedb": "^1.0.0-beta || ^2.0.0"
   },
   "devDependencies": {
-    "async": "^1.5.2",
+    "async": "^3.2.3",
     "chai": "^4.2.0",
     "coveralls": "^3.0.7",
     "mocha": "^6.2.2",


### PR DESCRIPTION
This change resolves a security warning by bumping our dev dependency
on `async`.