### PR TITLE
Support $aggregate, upgrade to mingo 6

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "lodash.clonedeep": "^4.5.0",
-    "mingo": "^4.1.5"
+    "mingo": "^6.1.0"
   },
   "peerDependencies": {
     "sharedb": "^1.0.0-beta || ^2.0.0 || ^3.0.0"


### PR DESCRIPTION
sharedb-mongo support Mongo aggregation pipelines via passing the pipeline in `$aggregate`.

This adds support for the same mechanism in sharedb-mingo-memory, and upgrades to the latest mingo@6.