### PR TITLE
🐛 Add query validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 #*#
 node_modules
 coverage
+package-lock.json

--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,0 @@
-*~
-#*#
-node_modules

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 var Mingo = require('mingo');
 var cloneDeep = require('lodash.clonedeep');
+var isObject = require('lodash.isobject');
 
 // This is designed for use in tests, so load all Mingo query operators
 require('mingo/init/system');
@@ -143,6 +144,10 @@ function extendMemoryDB(MemoryDB) {
   // Build a query object that mimics how the query would be executed if it were
   // made against snapshots persisted with `sharedb-mongo`
   function castToSnapshotQuery(query) {
+    if (!isObject(query) || Array.isArray(query)) {
+      throw new Error('Invalid mongo query format');
+    }
+
     var snapshotQuery = {};
     var propertySegments;
     for (var property in query) {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "lodash.clonedeep": "^4.5.0",
+    "lodash.isobject": "^3.0.2",
     "mingo": "^6.1.0"
   },
   "peerDependencies": {

--- a/test/query.js
+++ b/test/query.js
@@ -246,6 +246,21 @@ module.exports = function() {
     });
   });
 
+  it('throws when the query is not an valid query', function(done) {
+    var db = this.db;
+    var query = {
+      $and: [
+        123,
+        {y: 1}
+      ]
+    };
+
+    db.query('testcollection', query, null, null, function(err) {
+      expect(err.message).to.be.equal('Invalid mongo query format');
+      done();
+    });
+  });
+
   describe('top-level boolean operator', function() {
     var snapshots = [
       {type: 'json0', v: 1, data: {x: 1, y: 1}, id: 'test1', m: null},


### PR DESCRIPTION
Sending this query to the query mechanism:
```
{
      $and: [
        123,
        {y: 1}
      ]
}
```

should throw the error, however our function `castToSnapshotQuery` changes it to:

```
{"$and":[{},{"data.y": 1}]}
```

Notice that the number `123` was converted to the empty object