### PR TITLE
Restrict to mingo <= 6.2.1, since mingo@6.2.2 breaks commonjs require of mingo/init/system

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "lodash.clonedeep": "^4.5.0",
     "lodash.isobject": "^3.0.2",
-    "mingo": "^6.1.0"
+    "mingo": "6.1.0 - 6.2.1"
   },
   "peerDependencies": {
     "sharedb": "^1.0.0-beta || ^2.0.0 || ^3.0.0"


### PR DESCRIPTION
[mingo@6.2.2](https://github.com/kofrasa/mingo/commit/874ab58ee60aa6b2d3c4f95cce1f819d047a4925) has a likely-inadvertent breaking change to a commonjs `require` of `mingo/init/system`.

```
 $ npm test

Error: Cannot find module 'mingo/init/system'
Require stack:
- ./share/sharedb-mingo-memory/index.js
- ./share/sharedb-mingo-memory/test/test.js
- ./share/sharedb-mingo-memory/node_modules/mocha/lib/mocha.js
- ./share/sharedb-mingo-memory/node_modules/mocha/lib/cli/one-and-dones.js
- ./share/sharedb-mingo-memory/node_modules/mocha/lib/cli/options.js
- ./share/sharedb-mingo-memory/node_modules/mocha/bin/mocha
```

For now, this fixes the issue by restricting to the previous mingo <= 6.2.1. That's safer than changing to the new `mingo/lib/init/system` path, since mingo might choose to undo the breaking change.