### PR TITLE
⬆️ Add support for `sharedb@4`

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "mingo": "6.1.0 - 6.2.1"
   },
   "peerDependencies": {
-    "sharedb": "^1.0.0-beta || ^2.0.0 || ^3.0.0"
+    "sharedb": "^1.0.0-beta || ^2.0.0 || ^3.0.0 || ^4.0.0"
   },
   "devDependencies": {
     "async": "^3.2.3",
@@ -30,7 +30,7 @@
     "mocha": "^6.2.2",
     "nyc": "^14.1.1",
     "ot-json1": "^1.0.1",
-    "sharedb": "^2.0.0",
+    "sharedb": "^3.0.0 || ^4.0.0",
     "sinon": "^11.1.2"
   },
   "author": "Avital Oliver",


### PR DESCRIPTION
The only breaking change in `sharedb@4` is dropping support for Node.js v14 (which this library has also done).